### PR TITLE
Expr_vars now set within add_nonlinear_constraint.

### DIFF
--- a/src/black_box_function.jl
+++ b/src/black_box_function.jl
@@ -112,7 +112,7 @@ Can be tagged with additional info.
     constraint::Union{JuMP.ConstraintRef, Expr}        # The "raw" constraint
     vars::Array{JuMP.VariableRef,1}                      # JuMP variables (flat)
     name::Union{String, Real} = ""                     # Function name
-    expr_vars = vars_from_expr(constraint, vars[1].model)          # Function inputs (nonflat JuMP variables)
+    expr_vars:: Union{Array, Nothing} = nothing        # Function inputs (nonflat JuMP variables)
     varmap::Union{Nothing,Array} = get_varmap(expr_vars, vars)     # ... with the required varmapping.
     fn::Union{Nothing, Function} = functionify(constraint)         # ... and actually evaluated f'n
     X::DataFrame = DataFrame([Float64 for i=1:length(vars)], string.(vars))

--- a/src/global_model.jl
+++ b/src/global_model.jl
@@ -99,7 +99,8 @@ end
 
 function add_nonlinear_constraint(gm::GlobalModel,
                      constraint::Union{JuMP.ScalarConstraint, JuMP.ConstraintRef, Expr};
-                     vars::Union{Nothing, Array{JuMP.VariableRef}} = nothing,
+                     vars::Union{Nothing, Array{JuMP.VariableRef, 1}} = nothing,
+                     expr_vars::Union{Nothing, Array} = nothing,
                      name::Union{Nothing, String} = nothing,
                      equality::Bool = false)
 """ Adds a new nonlinear constraint to Global Model.
@@ -113,11 +114,14 @@ function add_nonlinear_constraint(gm::GlobalModel,
     if isnothing(name)
         name = string("bbf", length(gm.bbfs) + 1)
     end
+    if isnothing(expr_vars) && constraint isa Expr
+        expr_vars = vars_from_expr(constraint, vars[1].model)
+    end
     if constraint isa JuMP.ScalarConstraint #TODO: clean up.
         con = JuMP.add_constraint(gm.model, bbf.constraint)
         JuMP.delete(gm.model, con)
-        new_bbf = BlackBoxFunction(constraint = con, vars = bbf_vars, equality = equality,
-                                   name = name)
+        new_bbf = BlackBoxFunction(constraint = con, vars = bbf_vars, expr_vars = expr_vars,
+                                   equality = equality, name = name)
         @assert length(new_bbf.vars) == length(new_bbf.varmap)
         push!(gm.bbfs, new_bbf)
         return
@@ -125,8 +129,8 @@ function add_nonlinear_constraint(gm::GlobalModel,
     if constraint isa JuMP.ConstraintRef
         JuMP.delete(gm.model, constraint)
     end
-    new_bbf = BlackBoxFunction(constraint = constraint, vars = bbf_vars, equality = equality,
-                               name = name)
+    new_bbf = BlackBoxFunction(constraint = constraint, vars = bbf_vars, expr_vars = expr_vars,
+                               equality = equality, name = name)
     @assert length(new_bbf.vars) == length(new_bbf.varmap)
     push!(gm.bbfs, new_bbf)
     return

--- a/test/src.jl
+++ b/test/src.jl
@@ -88,7 +88,8 @@ sets = [MOI.GreaterThan(2), MOI.EqualTo(0), MOI.SecondOrderCone(3), MOI.Geometri
 @test functionify(expr) isa Function
 # @test_throws
 bbfs = [BlackBoxFunction(constraint = nl_constrs[1], vars = [x[4], x[5], z]),
-        BlackBoxFunction(constraint = expr, vars = flat([x[1:4], y[1:2], z]))]
+        BlackBoxFunction(constraint = expr, vars = flat([x[1:4], y[1:2], z]),
+                         expr_vars = [x,y,z])]
 
 # Evaluation (scalar)
 # Quadratic (JuMP compatible) constraint


### PR DESCRIPTION
This way, we can set the function variables as needed, when it is difficult to parse them through the expressions themselves. 

(Will be useful for GAMS parsing.)